### PR TITLE
fix(workflow): remove fetch depth limit in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.8
         uses: actions/setup-python@v2.3.1
         with:


### PR DESCRIPTION
the fetch depth was set to 1, meaning the git log did not have access to older commit messages